### PR TITLE
Domains from .lan to .home.arpa

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ It has a very simple infrastructure with the tools you might need when working o
 
 It contains:
 
-- WireGuard (VPN) - vpn.lan
-- PiHole (DNS) - dns.lan
-- PwnDoc - pwndoc.lan
-- Gitea  - git.lan
-- Wiki.js - wiki.lan
-- Netdata - netdata.lan
+- WireGuard (VPN) - vpn.home.arpa
+- PiHole (DNS) - dns.home.arpa
+- PwnDoc - pwndoc.home.arpa
+- Gitea  - git.home.arpa
+- Wiki.js - wiki.home.arpa
+- Netdata - netdata.home.arpa
 - Nginx
 - KMS
 - Rsyslog
@@ -122,7 +122,7 @@ docker restart gitea gitea-postgres
 
 ## PiHole
 
-1. Access to `https://dns.lan/admin/settings.php?tab=teleporter`
+1. Access to `https://dns.home.arpa/admin/settings.php?tab=teleporter`
 2. Upload the backup file and press on restore.
 3. Access the container and update the list of ad-serving domains
 ```bash

--- a/default.conf
+++ b/default.conf
@@ -24,7 +24,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name dns.lan;
+    server_name dns.home.arpa;
     ssl_certificate /etc/nginx/ssl/nginx-selfsigned.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx-selfsigned.key;
 
@@ -46,7 +46,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name git.lan;
+    server_name git.home.arpa;
     client_max_body_size 500m;
     ssl_certificate /etc/nginx/ssl/nginx-selfsigned.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx-selfsigned.key;
@@ -68,7 +68,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name pwndoc.lan;
+    server_name pwndoc.home.arpa;
     ssl_certificate /etc/nginx/ssl/nginx-selfsigned.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx-selfsigned.key;
 
@@ -90,7 +90,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name wiki.lan;
+    server_name wiki.home.arpa;
     ssl_certificate /etc/nginx/ssl/nginx-selfsigned.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx-selfsigned.key;
 
@@ -111,7 +111,7 @@ server {
 # HTTPS vhost for wg-easy
 server {
     listen 443 ssl;
-    server_name vpn.lan;
+    server_name vpn.home.arpa;
 
     ssl_certificate     /etc/nginx/ssl/nginx-selfsigned.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx-selfsigned.key;
@@ -131,7 +131,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name netdata.lan;
+    server_name netdata.home.arpa;
     ssl_certificate /etc/nginx/ssl/nginx-selfsigned.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx-selfsigned.key;
 

--- a/docker-compose-bkp.yml
+++ b/docker-compose-bkp.yml
@@ -21,12 +21,12 @@ services:
       TZ: 'Europe/Madrid'
       FTLCONF_webserver_api_password: '<PIHOLE_PASSWD>'
       FTLCONF_dns_hosts: |
-        <HOST_IP> vpn.lan
-        <HOST_IP> dns.lan
-        <HOST_IP> wiki.lan
-        <HOST_IP> netdata.lan
-        <HOST_IP> pwndoc.lan
-        <HOST_IP> git.lan
+        <HOST_IP> vpn.home.arpa
+        <HOST_IP> dns.home.arpa
+        <HOST_IP> wiki.home.arpa
+        <HOST_IP> netdata.home.arpa
+        <HOST_IP> pwndoc.home.arpa
+        <HOST_IP> git.home.arpa
     volumes:
       - './PiHole/backup/:/backup'
       - './PiHole/etc-pihole:/etc/pihole'
@@ -144,7 +144,7 @@ services:
     container_name: netdata
     image: netdata/netdata
     pid: host
-    hostname: netdata.lan
+    hostname: netdata.home.arpa
     healthcheck:
       test: ["CMD", "curl", "-f", "http://172.17.0.1:19999"]
       interval: 1m30s

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ echo
 
 # Adding domains into /etc/hosts
 line="127.0.0.1"
-for h in vpn.lan dns.lan wiki.lan netdata.lan pwndoc.lan git.lan; do
+for h in vpn.home.arpa dns.home.arpa wiki.home.arpa netdata.home.arpa pwndoc.home.arpa git.home.arpa; do
   grep -qE "^[^#]*[[:space:]]$h([[:space:]]|\$)" /etc/hosts || line+=" $h"
 done
 [ "$line" != "127.0.0.1" ] && echo "$line" | sudo tee -a /etc/hosts >/dev/null
@@ -100,7 +100,7 @@ cd ./Nginx/ssl && \
   openssl req -x509 -nodes -days 36500 -newkey rsa:2048 \
     -keyout nginx-selfsigned.key \
     -out nginx-selfsigned.crt \
-    -subj "/C=ES/ST=Madrid/L=Madrid/O=Home/OU=Root CA/CN=server.lan"
+    -subj "/C=ES/ST=Madrid/L=Madrid/O=Home/OU=Root CA/CN=server.home.arpa"
 cd -
 
 # Rsyslog


### PR DESCRIPTION
This way is compliance with local access to internal network services in all devices